### PR TITLE
Add ckanext-hierarchy snippet to organization.json schema

### DIFF
--- a/ckanext/lacounts/schemas/organization.json
+++ b/ckanext/lacounts/schemas/organization.json
@@ -59,6 +59,13 @@
             ]
         },
         {
+            "field_name": "not_used",
+            "label": "Parent",
+            "display_snippet": null,
+            "form_snippet": "org_hierarchy.html",
+            "validators": "ignore_missing"
+        },
+        {
             "field_name": "image",
             "form_snippet": "organization_image.html",
             "label": "Image"


### PR DESCRIPTION
Adds hierarchy field to organizations (publishers) schema. ckanext-heirarchy added to development ckan platform here: https://github.com/okfn/docker-ckan-lacounts/commit/cd08b8819dc573a86b0237d35418340a4a03d8b9

Part of #29.