### PR TITLE
Create featured topics and render topic image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ CSS is built with PostCSS. Do so with `grunt postcss`.
 JS is built (minified) with `grunt uglify`.
 
 You can watch both for changes with `grunt`.
+
+### Create featured topics
+
+There are pre-defined _topics_ (groups) that can be created with a paster command.
+
+#### In development
+
+`docker-compose -f docker-compose.dev.yml run --rm ckan-dev bash -c "cd src_extensions/ckanext-lacounts && python setup.py develop && paster create_featured_topics"`
+
+#### In production & staging

--- a/ckanext/lacounts/commands.py
+++ b/ckanext/lacounts/commands.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from ckan.common import OrderedDict
+from ckan.plugins import toolkit
+import ckanapi
+
+
+groups = OrderedDict([
+    ('education', 'Education'),
+    ('environment', 'Environment'),
+    ('health', 'Health'),
+    ('housing', 'Housing'),
+    ('immigration', 'Immigration'),
+    ('transportation', 'Transportation')
+])
+
+
+class CreateFeaturedTopics(toolkit.CkanCommand):
+    '''Create featured topics
+
+    Usage:
+      create_featured_topics             - create featured topics
+    '''
+
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+    max_args = 0
+    min_args = 0
+
+    def command(self):
+        self._load_config()
+
+        local_ckan = ckanapi.LocalCKAN()
+
+        for name, title in groups.items():
+            try:
+                local_ckan.action.group_create(
+                    name=name,
+                    title=title,
+                    type='topic'
+                )
+                print('Created group %s ' % name)
+            except ckanapi.ValidationError as e:
+                if 'Group name already exists in database' \
+                   in e.error_dict['name']:
+                    print('Group %s already exists' % name)

--- a/ckanext/lacounts/helpers.py
+++ b/ckanext/lacounts/helpers.py
@@ -1,0 +1,21 @@
+import ckan.plugins.toolkit as toolkit
+
+
+def get_image_for_group(group_name):
+    '''
+    Render an inline svg snippet for the named group (topic). These groups
+    correlate with those created by the `create_featured_topics` command.
+    '''
+    jinja_env = toolkit.config['pylons.app_globals'].jinja_env
+    groups = {
+        'education': 'icons/book.svg',
+        'environment': 'icons/leaf.svg',
+        'health': 'icons/heart.svg',
+        'housing': 'icons/keys.svg',
+        'immigration': 'icons/passport.svg',
+        'transportation': 'icons/bus.svg'
+    }
+    svg = jinja_env.get_template(groups[group_name])
+    img = toolkit.literal("<span class='image %s'>" % group_name
+                          + svg.render() + "</span>")
+    return img

--- a/ckanext/lacounts/plugin.py
+++ b/ckanext/lacounts/plugin.py
@@ -2,31 +2,13 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 
+from ckanext.lacounts.helpers import get_image_for_group
+
 
 class LacountsPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.ITemplateHelpers)
-
-    @staticmethod
-    def get_image_for_group(group_name):
-        '''
-        Render an inline svg snippet for the named group (topic). These groups
-        correlate with those created by the `create_featured_topics` command.
-        '''
-        jinja_env = toolkit.config['pylons.app_globals'].jinja_env
-        groups = {
-            'education': 'icons/book.svg',
-            'environment': 'icons/leaf.svg',
-            'health': 'icons/heart.svg',
-            'housing': 'icons/keys.svg',
-            'immigration': 'icons/passport.svg',
-            'transportation': 'icons/bus.svg'
-        }
-        svg = jinja_env.get_template(groups[group_name])
-        img = toolkit.literal("<span class='image %s'>" % group_name
-                              + svg.render() + "</span>")
-        return img
 
     # IConfigurer
     def update_config(self, config_):
@@ -36,4 +18,4 @@ class LacountsPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # ITemplateHelpers
     def get_helpers(self):
-        return {'get_image_for_group': self.get_image_for_group}
+        return {'get_image_for_group': get_image_for_group}

--- a/ckanext/lacounts/plugin.py
+++ b/ckanext/lacounts/plugin.py
@@ -6,10 +6,34 @@ from ckan.lib.plugins import DefaultTranslation
 class LacountsPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITranslation)
+    plugins.implements(plugins.ITemplateHelpers)
+
+    @staticmethod
+    def get_image_for_group(group_name):
+        '''
+        Render an inline svg snippet for the named group (topic). These groups
+        correlate with those created by the `create_featured_topics` command.
+        '''
+        jinja_env = toolkit.config['pylons.app_globals'].jinja_env
+        groups = {
+            'education': 'icons/book.svg',
+            'environment': 'icons/leaf.svg',
+            'health': 'icons/heart.svg',
+            'housing': 'icons/keys.svg',
+            'immigration': 'icons/passport.svg',
+            'transportation': 'icons/bus.svg'
+        }
+        svg = jinja_env.get_template(groups[group_name])
+        img = toolkit.literal("<span class='image %s'>" % group_name
+                              + svg.render() + "</span>")
+        return img
 
     # IConfigurer
-
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'lacounts')
+
+    # ITemplateHelpers
+    def get_helpers(self):
+        return {'get_image_for_group': self.get_image_for_group}

--- a/ckanext/lacounts/templates/group/snippets/group_item.html
+++ b/ckanext/lacounts/templates/group/snippets/group_item.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+  {% block image %}
+    {{ h.get_image_for_group(group.name) }}
+  {% endblock %}

--- a/ckanext/lacounts/templates/group/snippets/info.html
+++ b/ckanext/lacounts/templates/group/snippets/info.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block image %}
+<div class="image {{ group.name }}">
+  <a href="{{ group.url }}">
+    {{ h.get_image_for_group(group.name) }}
+  </a>
+</div>
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ setup(
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
+
+        [paste.paster_command]
+        create_featured_topics=ckanext.lacounts.commands:CreateFeaturedTopics
     ''',
 
     # If you are changing from the default layout of your extension, you may


### PR DESCRIPTION
This PR adds a paster command to create featured topics, and a template helper to render the appropriate topic inline svg image.

@amercader Can you have a look at this just as a general review

@smth Can you confirm the approach here for embedding the svg image. I've left them unstyled for now, as I thought I should leave that up to you.

Part of #30.