### PR TITLE
Integrate socrata harvester

### DIFF
--- a/ckanext/lacounts/harvest/harvesters/socrata.py
+++ b/ckanext/lacounts/harvest/harvesters/socrata.py
@@ -1,13 +1,24 @@
-import logging
-from ckanext.harvest.harvesters import CKANHarvester
+import json
+
+from ckanext.socrata.plugin import SocrataHarvester
 from ckanext.lacounts.harvest import helpers
-log = logging.getLogger(__name__)
 
 
-#TODO: switch to SocrataHarvester
-class LacountsSocrataHarvester(CKANHarvester):
+class LacountsSocrataHarvester(SocrataHarvester):
+
+    def import_stage(self, harvest_object):
+        try:
+            package = json.loads(harvest_object.content)
+        except TypeError:
+            # harvest_object may not have content. For example, if set for
+            # deletion.
+            pass
+        else:
+            package = helpers.process_package(package, harvest_object)
+            harvest_object.content = json.dumps(package)
+        return super(LacountsSocrataHarvester, self) \
+            .import_stage(harvest_object)
 
     def process_package(self, package, harvest_object):
-        log.debug('In LacountsSocrataHarvester process_package')
         package = helpers.process_package(package, harvest_object)
         return package

--- a/ckanext/lacounts/harvest/harvesters/socrata.py
+++ b/ckanext/lacounts/harvest/harvesters/socrata.py
@@ -1,23 +1,8 @@
-import json
-
 from ckanext.socrata.plugin import SocrataHarvester
 from ckanext.lacounts.harvest import helpers
 
 
 class LacountsSocrataHarvester(SocrataHarvester):
-
-    def import_stage(self, harvest_object):
-        try:
-            package = json.loads(harvest_object.content)
-        except TypeError:
-            # harvest_object may not have content. For example, if set for
-            # deletion.
-            pass
-        else:
-            package = helpers.process_package(package, harvest_object)
-            harvest_object.content = json.dumps(package)
-        return super(LacountsSocrataHarvester, self) \
-            .import_stage(harvest_object)
 
     def process_package(self, package, harvest_object):
         package = helpers.process_package(package, harvest_object)

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         [ckan.plugins]
         lacounts=ckanext.lacounts.plugin:LacountsPlugin
         lacounts_ckan_harvester=ckanext.lacounts.harvest.harvesters.ckan:LacountsCKANHarvester
+        lacounts_socrata_harvester=ckanext.lacounts.harvest.harvesters.socrata:LacountsSocrataHarvester
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
Adds the `lacounts_socrata_harvester` ckan harvester, and small change to allow packages to have no content, which is the case for `HarvestObjects` that represent deletions. This corresponds with work on ckanext-socrata here: https://github.com/okfn/ckanext-socrata/pull/1