### PR TITLE
Add ESRI Geoportal harvester

### DIFF
--- a/ckanext/lacounts/harvest/harvesters/esri.py
+++ b/ckanext/lacounts/harvest/harvesters/esri.py
@@ -1,13 +1,78 @@
+from __future__ import unicode_literals
+
+import json
+
+from ckanext.dcat.harvesters import DCATRDFHarvester
+from ckanext.dcat.profiles import EuropeanDCATAPProfile
+from ckanext.lacounts.helpers import toolkit
+
 import logging
-from ckanext.harvest.harvesters import CKANHarvester
-from ckanext.lacounts.harvest import helpers
 log = logging.getLogger(__name__)
 
 
-#TODO: switch to ESRIHarvester
-class LacountsESRIHarvester(CKANHarvester):
+class LacountsESRIGeoportalHarvester(DCATRDFHarvester):
+    '''
+    A CKAN Harvester for ESRI Geoportals.
+    '''
 
     def process_package(self, package, harvest_object):
-        log.debug('In LacountsESRIHarvester process_package')
-        package = helpers.process_package(package, harvest_object)
+        '''
+        Subclasses can override this method to perform additional processing on
+        package dicts during import_stage.
+        '''
         return package
+
+    def info(self):
+        return {
+            'name': 'esri_geoportal',
+            'title': 'ESRI Geoportal',
+            'description': 'Harvest from an ESRI Geoportal'
+        }
+
+    def validate_config(self, source_config):
+        '''
+        Source format should always be application/ld+json.
+        '''
+        conf = \
+            super(LacountsESRIGeoportalHarvester, self) \
+            .validate_config(source_config)
+        if not conf:
+            conf = {}
+        else:
+            conf = json.loads(conf)
+        conf['rdf_format'] = "application/ld+json"
+        return json.dumps(conf)
+
+
+class LacountsESRIGeoportalProfile(EuropeanDCATAPProfile):
+    '''
+    An RDF profile for the Lacounts ESRI Geoportal harvester.
+    '''
+
+    def parse_dataset(self, dataset_dict, dataset_ref):
+
+        def _remove_pkg_dict_extra(pkg_dict, key):
+            '''Remove the dataset extra with the provided key, and return its
+            value.
+            '''
+            extras = pkg_dict['extras'] if 'extras' in pkg_dict else []
+            for extra in extras:
+                if extra['key'] == key:
+                    val = extra['value']
+                    pkg_dict['extras'] = \
+                        [e for e in extras if not e['key'] == key]
+                    return val
+            return None
+
+        dataset_dict = super(LacountsESRIGeoportalProfile, self) \
+            .parse_dataset(dataset_dict, dataset_ref)
+
+        schema = toolkit.h.scheming_get_dataset_schema('dataset')
+        field_names = [i['field_name'] for i in schema['dataset_fields']]
+        # If a field name is an extra in dataset_dict, promote to the top level
+        for name in field_names:
+            val = _remove_pkg_dict_extra(dataset_dict, name)
+            if val:
+                dataset_dict[name] = val
+
+        return dataset_dict

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ setup(
         lacounts=ckanext.lacounts.plugin:LacountsPlugin
         lacounts_ckan_harvester=ckanext.lacounts.harvest.harvesters.ckan:LacountsCKANHarvester
         lacounts_socrata_harvester=ckanext.lacounts.harvest.harvesters.socrata:LacountsSocrataHarvester
+        lacounts_esrigeoportal_harvester=ckanext.lacounts.harvest.harvesters.esri:LacountsESRIGeoportalHarvester
+
+        [ckan.rdf.profiles]
+        lacounts_esri_geoportal_profile=ckanext.lacounts.harvest.harvesters.esri:LacountsESRIGeoportalProfile
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
This is a custom ckanext-dcat rdf harvester, with a custom rdf profile,
based on the default Euro profile.

The custom harvester ensures the rdf format is always
'application/ld_json'.

The custom DCAT profile reads the dataset schema, and promotes extras
that should be top level properties.

This requires [ckanext-dcat](https://github.com/ckan/ckanext-dcat) is installed.

Closes #9.